### PR TITLE
Progress bars with popovers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache: pip
 matrix:
   fast_finish: true
 # commands to install dependencies
+before_install:
+  # If python version is < 3, then don't run BamQC module
+  - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then sed -i '/bamqc/d' setup.py docs/README.md multiqc/utils/config_defaults.yaml; fi
 install:
   - python setup.py install
   - git clone https://github.com/ewels/MultiQC_TestData.git test_data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
     * Null values (`-`) in reports now handled properly. Bargraphs always shown despite varying thresholds. ([@vladsaveliev](https://github.com/vladsaveliev))
 * **RNA-SeQC**
     * Don't create the report section for Gene Body Coverage if no data is given
+* **Samtools**
+    * Fixed edge case bug where MultiQC could crash if a sample had zero count coverage with idxstats.
 * **Tophat**
     * Fixed bug where some samples could be given a blank sample name ([@lparsons](https://github.com/lparsons))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 * Removed Python dependency for `enum34` ([@boulund](https://github.com/boulund))
 * Columns can be added to `General Stats` table for custom content/module.
 * New `--ignore-symlinks` flag which will ignore symlinked directories and files.
+* New `--no-megaqc-upload` flag which disables automatically uploading data to MegaQC
 
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.

--- a/multiqc/modules/bamqc/assets/css/multiqc_bamqc.css
+++ b/multiqc/modules/bamqc/assets/css/multiqc_bamqc.css
@@ -1,0 +1,44 @@
+/* CSS for the BamQC MultiQC Module */
+
+/* BamQC statuses popovers */
+.bamqc_passfail_progress .progess-bar {
+  cursor: pointer;
+}
+
+.mqc-section-bamqc .popover .popover-content {
+  font-size: 11px;
+  max-height: 300px;
+  white-space: nowrap;
+  overflow: auto;
+}
+
+.popover-success .popover-title {
+  background-color: #dff0d8;
+  color: #3c763d;
+}
+
+.popover-danger .popover-title {
+  background-color: #f2dede;
+  color: #a94442;
+}
+
+.bamqc-popover-intro {
+  margin: 5px 5px 0;
+  padding: 3px 5px;
+  border: 1px dashed #ccc;
+  border-radius: 5px;
+  font-size: 10px;
+  color: #999;
+  background-color: #fafafa;
+}
+
+.bamqc-popover-intro a {
+  color: #999;
+  text-decoration: underline;
+}
+
+.bamqc_passfail_progress {
+  width: 100px;
+  display: inline-block;
+  margin: 0 0 -2px 20px;
+}

--- a/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
+++ b/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
@@ -1,0 +1,108 @@
+// Set up listeners etc on page load
+$(function () {
+
+    // Add the pass / fails counts to each of the BamQC submodule headings
+    $.each(bamqc_passfails, function(k, vals){
+        var pid = '#bamqc_'+k;
+        var total = 0;
+        var v = { 'pass': 0, 'fail': 0 };
+        $.each(vals, function(s_name, status){
+            total += 1;
+            v[status] += 1;
+        });
+        var p_bar = '<div class="progress bamqc_passfail_progress"> \
+            <div class="progress-bar progress-bar-success" style="width: '+(v['pass']/total)*100+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-danger" style="width: '+(v['fail']/total)*100+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples are more than two standard deviations away from the mean">'+v['fail']+'</div> \
+        </div>';
+        $(pid).append(p_bar);
+    });
+
+    // Create popovers on click
+    $('.mqc-section-bamqc .bamqc_passfail_progress .progress-bar').mouseover(function(){
+        // Does this element already have a popover?
+        if ($(this).attr('data-original-title')) { return false; }
+        // Create it
+        var pid = $(this).closest('h3').attr('id');
+        var k = pid.substr(6);
+        var vals = bamqc_passfails[k];
+        var passes = $(this).hasClass('progress-bar-success') ? true : false;
+        var fails = $(this).hasClass('progress-bar-danger') ? true : false;
+        var pclass = '';
+        if(passes){ pclass = 'success'; }
+        if(fails){ pclass = 'danger'; }
+        var samples = Array();
+        $.each(vals, function(s_name, status){
+            if(status == 'pass' && passes){ samples.push(s_name); }
+            else if(status == 'fail' && fails){ samples.push(s_name); }
+        });
+        $($(this)).popover({
+            animation: true,
+            title: $(this).attr('title'),
+            content: samples.sort().join('<br>'),
+            html: true,
+            trigger: 'hover click focus',
+            placement: 'bottom auto',
+            template: '<div class="popover popover-'+pclass+'" role="tooltip"> \
+                <div class="arrow"></div>\
+                <h3 class="popover-title"></h3>\
+                <div class="bamqc-popover-intro">\
+                    Click bar to fix in place <br>\
+                    <a href="#" class="bamqc-status-highlight"><span class="glyphicon glyphicon-pushpin"></span> Highlight these samples</a><br>\
+                    <a href="#" class="bamqc-status-hideothers"><span class="glyphicon glyphicon-eye-close"></span> Show only these samples</a>\
+                </div>\
+                <div class="popover-content"></div>\
+            </div>'
+        }).popover('show');
+    });
+
+    // Listener for Status higlight click
+    $('.mqc-section-bamqc .bamqc_passfail_progress').on('click', '.bamqc-status-highlight', function(e){
+        e.preventDefault();
+        // Get sample names and highlight colour
+        var samples = $(this).parent().parent().find('.popover-content').html().split('<br>');
+        var f_col = mqc_colours[mqc_colours_idx];
+        // Add sample names to the toolbox
+        for (i = 0; i < samples.length; i++) {
+            var f_text = samples[i];
+            $('#mqc_col_filters').append('<li style="color:'+f_col+';"><span class="hc_handle"><span></span><span></span></span><input class="f_text" value="'+f_text+'"/><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>');
+        }
+        // Apply highlights and open toolbox
+        apply_mqc_highlights();
+        mqc_toolbox_openclose('#mqc_cols', true);
+        // Update next highlight colour
+        mqc_colours_idx += 1;
+        if(mqc_colours_idx >= mqc_colours.length){ mqc_colours_idx = 0; }
+        $('#mqc_colour_filter_color').val(mqc_colours[mqc_colours_idx]);
+        // Hide the popover
+        $(this).closest('.popover').popover('hide');
+    });
+
+    // Listener for Status hide others click
+    $('.mqc-section-bamqc .bamqc_passfail_progress').on('click', '.bamqc-status-hideothers', function(e){
+        e.preventDefault();
+        // Get sample names
+        var samples = $(this).parent().parent().find('.popover-content').html().split('<br>');
+        // Check if we're already hiding anything, remove after confirm if so
+        if($('#mqc_hidesamples_filters li').length > 0){
+            if(!confirm($('#mqc_hidesamples_filters li').length+' Hide filters already exist - discard?')){
+                return false;
+            } else {
+                $('#mqc_hidesamples_filters').empty();
+            }
+        }
+        // Set to "show only" and disable regex
+        $('.mqc_hidesamples_showhide[value="show"]').prop('checked', true);
+        $('#mqc_hidesamples .mqc_regex_mode .re_mode').removeClass('on').addClass('off').text('off');
+        // Add sample names to the toolbox
+        for (i = 0; i < samples.length; i++) {
+            var f_text = samples[i];
+            $('#mqc_hidesamples_filters').append('<li><input class="f_text" value="'+f_text+'" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>');
+        }
+        // Apply highlights and open toolbox
+        apply_mqc_hidesamples();
+        mqc_toolbox_openclose('#mqc_hidesamples', true);
+        // Hide the popover
+        $(this).closest('.popover').popover('hide');
+    });
+
+});

--- a/multiqc/modules/bamqc/bamqc.py
+++ b/multiqc/modules/bamqc/bamqc.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
 """ MultiQC module to parse output from BamQC """
-
 from __future__ import print_function
+import sys
+import logging
+# Initialise the logger
+log = logging.getLogger(__name__)
+
 from collections import OrderedDict
 from multiqc import config
 from multiqc.plots import bargraph
 from multiqc.modules.base_module import BaseMultiqcModule
-import logging
 import os
 import io
 import json
-
-# Initialise the logger
-log = logging.getLogger(__name__)
+import statistics
 
 class MultiqcModule(BaseMultiqcModule):
     """ BamQC module """ 
@@ -32,6 +33,9 @@ class MultiqcModule(BaseMultiqcModule):
             file_name = f['s_name'].replace(".annotated", "")
             self.parse_bamqc_log(f['f'], file_name, f)
 
+        # check reads for each sample and mark any outlier as 'fail'; otherwise, mark it as 'pass'    
+        self.find_outliers()
+
         # Filter to strip out ignored sample names
         self.bamqc_data = self.ignore_samples(self.bamqc_data)
 
@@ -43,8 +47,23 @@ class MultiqcModule(BaseMultiqcModule):
         # Write parsed report data to a file 
         self.write_data_file(self.bamqc_data, 'multiqc_bamqc')
 
+        # Add to self.css and self.js to be included in template
+        self.css = { 'assets/css/multiqc_bamqc.css' : os.path.join(os.path.dirname(__file__), 'assets', 'css', 'multiqc_bamqc.css') }
+        self.js = { 'assets/js/multiqc_bamqc.js' : os.path.join(os.path.dirname(__file__), 'assets', 'js', 'multiqc_bamqc.js') }
+
         # Basic Stats Table
 #       self.bamqc_general_table()
+
+        # Add the statuses to the intro for multiqc_bamqc.js to pick up
+        statuses = dict()
+        for s_name in self.bamqc_data:
+            for section, status in self.bamqc_data[s_name]['statuses'].items():
+                    section = section.lower().replace(' ', '_')
+                    try:
+                            statuses[section][s_name] = status
+                    except KeyError:
+                            statuses[section] = {s_name: status}
+        self.intro += '<script type="text/javascript">bamqc_passfails = {};</script>'.format(json.dumps(statuses))
 
         # Add each Sample Read Plot section in order
         self.reads_on_target_plot()
@@ -98,6 +117,38 @@ class MultiqcModule(BaseMultiqcModule):
                if not (p in self.bamqc_data[s_name].keys()):
                        log.warning("Data for {} is missing!".format(p))
 
+    # an outlier is a value which is more than 2 standard deviations away from the mean in a dataset
+    def find_outliers(self):
+        reads = []
+        mean = 0 
+        stdev = 0
+        property_list = ['reads on target', 'reads per start point', 'total reads', 'paired reads', \
+                        'mapped reads', 'aligned bases', 'soft clip bases', 'insert mean']
+        for property in property_list:
+
+                for s_name in self.bamqc_data.keys():
+                        reads.append(self.bamqc_data[s_name][property])
+                        # keeping track of if any read is an outlier (more than two standard deviations away from the mean)
+                        if 'statuses' not in self.bamqc_data[s_name]:
+                                    self.bamqc_data[s_name]['statuses'] = dict()
+
+                try:
+                        mean = statistics.mean(reads)
+                        stdev = statistics.stdev(reads)
+                except Exception as e:
+                        log.warning("Not enough data is available to calculate mean and stdev!")
+                        log.debug("Reads are '{}'".format(reads))
+
+                for s_name in self.bamqc_data.keys():
+                        s_reads = self.bamqc_data[s_name][property]
+                        if s_reads > (mean + 2 * stdev) or s_reads < (mean - 2 * stdev):
+                                   self.bamqc_data[s_name]['statuses'][property] = 'fail'
+                        else:
+                                   self.bamqc_data[s_name]['statuses'][property] = 'pass'
+
+                # reset the list
+                reads = [] 
+
     def reads_on_target_plot(self):
 #       Bar plots showing sample names and values for reads on target
         pconfig = {
@@ -111,13 +162,27 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "reads on target" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['reads on target'] = self.bamqc_data[sample]['reads on target']
+                if self.bamqc_data[sample]['statuses']['reads on target'] == 'fail':
+                        bdata[sample]['reads on target fail'] = self.bamqc_data[sample]['reads on target']
+                else:
+                        bdata[sample]['reads on target'] = self.bamqc_data[sample]['reads on target']
+
+        # specify colors to distinguish passed values and outliers
+        cats = OrderedDict()
+        cats['reads on target'] = {
+                'name': 'Reads on Target',
+                'color': '#3ea540'  # passed: bars are plotted in green
+        }
+        cats['reads on target fail'] = {
+                'name': 'Reads on Target (Outliers)',
+                'color': '#bf3939'  # failed: bars are plotted in red
+        }
 
         self.add_section (
                 name = 'Reads on Target',
                 anchor = 'bamqc_reads_on_target',
                 description = 'Reads on target data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def reads_per_start_point_plot(self):
@@ -135,13 +200,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "reads per start point" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['reads per start point'] = self.bamqc_data[sample]['reads per start point']
+                if self.bamqc_data[sample]['statuses']['reads per start point'] == 'fail':
+                        bdata[sample]['reads per start point fail'] = self.bamqc_data[sample]['reads per start point']
+                else:
+                        bdata[sample]['reads per start point'] = self.bamqc_data[sample]['reads per start point']
+
+        cats = OrderedDict()
+        cats['reads per start point'] = {
+                'name': 'Reads per Start Point',
+                'color': '#3ea540'  # green
+        }
+        cats['reads per start point fail'] = {
+                'name': 'Reads per Start Point (Outliers)',
+                'color': '#bf3939'  # red
+        }
 
         self.add_section (
                 name = 'Reads per Start Point',
                 anchor = 'bamqc_reads_per_start_point',
                 description = 'Reads per Start Point data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def total_reads_plot(self):
@@ -157,13 +235,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "total reads" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['total reads'] = self.bamqc_data[sample]['total reads']
+                if self.bamqc_data[sample]['statuses']['total reads'] == 'fail':
+                        bdata[sample]['total reads fail'] = self.bamqc_data[sample]['total reads']
+                else:
+                        bdata[sample]['total reads'] = self.bamqc_data[sample]['total reads']
+
+        cats = OrderedDict()
+        cats['total reads'] = {
+                'name': 'Total Reads',
+                'color': '#3ea540'   # green
+        }
+        cats['total reads fail'] = {
+                'name': 'Total Reads (Outliers)',
+                'color': '#bf3939'   # red
+        }
 
         self.add_section (
                 name = 'Total Reads',
                 anchor = 'bamqc_total_reads',
                 description = 'Total Reads data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def paired_reads_plot(self):
@@ -179,13 +270,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "paired reads" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['paired reads'] = self.bamqc_data[sample]['paired reads']
+                if self.bamqc_data[sample]['statuses']['paired reads'] == 'fail':
+                        bdata[sample]['paired reads fail'] = self.bamqc_data[sample]['paired reads']
+                else:
+                        bdata[sample]['paired reads'] = self.bamqc_data[sample]['paired reads']
+
+        cats = OrderedDict()
+        cats['paired reads'] = {
+                'name': 'Paired Reads',
+                'color': '#3ea540'   # green
+        }
+        cats['paired reads fail'] = {
+                'name': 'Paired Reads (Outliers)',
+                'color': '#bf3939'    # red
+        }
 
         self.add_section (
                 name = 'Paired Reads',
                 anchor = 'bamqc_paired_reads',
                 description = 'Paired reads data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def mapped_reads_plot(self):
@@ -201,13 +305,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "mapped reads" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['mapped reads'] = self.bamqc_data[sample]['mapped reads']
+                if self.bamqc_data[sample]['statuses']['mapped reads'] == 'fail':
+                        bdata[sample]['mapped reads fail'] = self.bamqc_data[sample]['mapped reads']
+                else:
+                        bdata[sample]['mapped reads'] = self.bamqc_data[sample]['mapped reads']
+
+        cats = OrderedDict() 
+        cats['mapped reads'] = {
+                'name': 'Mapped Reads',
+                'color': '#3ea540'    # green
+        }
+        cats['mapped reads fail'] = {
+                'name': 'Mapped Reads (Outliers)',
+                'color': '#bf3939'    # red
+        }
 
         self.add_section (
                 name = 'Mapped Reads',
                 anchor = 'bamqc_mapped_reads',
                 description = 'Mapped Reads data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def aligned_bases_plot(self):
@@ -223,13 +340,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "aligned bases" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['aligned bases'] = self.bamqc_data[sample]['aligned bases']
+                if self.bamqc_data[sample]['statuses']['aligned bases'] == 'fail':
+                        bdata[sample]['aligned bases fail'] = self.bamqc_data[sample]['aligned bases']
+                else:
+                        bdata[sample]['aligned bases'] = self.bamqc_data[sample]['aligned bases']
+
+        cats = OrderedDict()
+        cats['aligned bases'] = {
+                'name': 'Aligned Bases',
+                'color': '#3ea540'    # green
+        }
+        cats['aligned bases fail'] = {
+                'name': 'Aligned Bases (Outliers)',
+                'color': '#bf3939'    # red
+        }
 
         self.add_section (
                 name = 'Aligned Bases',
                 anchor = 'bamqc_aligned_bases',
                 description = 'Aligned Bases data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def soft_clip_bases_plot(self):
@@ -245,13 +375,26 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "soft clip bases" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['soft clip bases'] = self.bamqc_data[sample]['soft clip bases']
+                if self.bamqc_data[sample]['statuses']['soft clip bases'] == 'fail':
+                        bdata[sample]['soft clip bases fail'] = self.bamqc_data[sample]['soft clip bases']
+                else:
+                        bdata[sample]['soft clip bases'] = self.bamqc_data[sample]['soft clip bases']
+
+        cats = OrderedDict()
+        cats['soft clip bases'] = {
+                'name': 'Soft Clip Bases',
+                'color': '#3ea540'    # green
+        }
+        cats['soft clip bases fail'] = {
+                'name': 'Soft Clip Bases (Outliers)',
+                'color': '#bf3939'    # red
+        }
 
         self.add_section (
                 name = 'Soft Clip Bases',
                 anchor = 'bamqc_soft_clip_bases',
                 description = 'Soft clip bases data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         )
 
     def insert_mean_plot(self):
@@ -269,11 +412,24 @@ class MultiqcModule(BaseMultiqcModule):
         # pull out information about "insert mean" from bamqc_data dictionary
         for sample in self.bamqc_data.keys():
                 bdata[sample] = dict()
-                bdata[sample]['insert mean'] = self.bamqc_data[sample]['insert mean']
+                if self.bamqc_data[sample]['statuses']['insert mean'] == 'fail':
+                        bdata[sample]['insert mean fail'] = self.bamqc_data[sample]['insert mean']
+                else:
+                        bdata[sample]['insert mean'] = self.bamqc_data[sample]['insert mean']
+
+        cats = OrderedDict()
+        cats['insert mean'] = {
+                'name': 'Insert Mean',
+                'color': '#3ea540'   # green
+        }
+        cats['insert mean fail'] = {
+                'name': 'Insert Mean (Outliers)',
+                'color': '#bf3939'   # red
+        }
 
         self.add_section (
                 name = 'Insert Mean',
                 anchor = 'bamqc_insert_mean',
                 description = 'Insert mean data for each sample.',
-                plot = bargraph.plot(bdata, None, pconfig)
+                plot = bargraph.plot(bdata, cats, pconfig)
         ) 

--- a/multiqc/modules/samtools/idxstats.py
+++ b/multiqc/modules/samtools/idxstats.py
@@ -99,7 +99,7 @@ class IdxstatsReportMixin():
                     try:
                         pdata[s_name][k] = self.samtools_idxstats[s_name][k]
                         pdata_norm[s_name][k] = float(self.samtools_idxstats[s_name][k]) / sample_mapped[s_name]
-                    except KeyError:
+                    except (KeyError, ZeroDivisionError):
                         pdata[s_name][k] = 0
                         pdata_norm[s_name][k] = 0
 
@@ -162,4 +162,3 @@ def parse_single_report(f):
         except (IndexError, ValueError):
             pass
     return parsed_data
-

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -159,6 +159,10 @@ logger = config.logger
                     is_flag = True,
                     help = "Creates PDF report with 'simple' template. Requires Pandoc to be installed."
 )
+@click.option('--no-megaqc-upload', 'no_megaqc_upload',
+                    is_flag = True,
+                    help = "Don't upload generated report to MegaQC, even if MegaQC options are found"
+)
 @click.option('-c', '--config', 'config_file',
                     type = click.Path(exists=True, readable=True),
                     multiple=True,
@@ -182,7 +186,7 @@ logger = config.logger
 
 def multiqc(analysis_dir, dirs, dirs_depth, no_clean_sname, title, report_comment, template, module_tag, module, exclude, outdir,
 ignore, ignore_samples, sample_names, file_list, filename, make_data_dir, no_data_dir, data_format, zip_data_dir, force, ignore_symlinks,
-export_plots, plots_flat, plots_interactive, lint, make_pdf, config_file, cl_config, verbose, quiet, **kwargs):
+export_plots, plots_flat, plots_interactive, lint, make_pdf, no_megaqc_upload, config_file, cl_config, verbose, quiet, **kwargs):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
 
         It searches a given directory for analysis logs and compiles a HTML report.
@@ -269,6 +273,10 @@ export_plots, plots_flat, plots_interactive, lint, make_pdf, config_file, cl_con
         lint_helpers.run_tests()
     if make_pdf:
         config.template = 'simple'
+    if no_megaqc_upload:
+        config.megaqc_upload = False
+    else:
+        config.megaqc_upload = True
     if sample_names:
         config.load_sample_names(sample_names)
     if module_tag is not None:
@@ -546,7 +554,7 @@ export_plots, plots_flat, plots_interactive, lint, make_pdf, config_file, cl_con
     plugin_hooks.mqc_trigger('before_report_generation')
 
     # Data Export / MegaQC integration - save report data to file or send report data to an API endpoint
-    if config.data_dump_file or config.megaqc_url:
+    if (config.data_dump_file or config.megaqc_url) and config.megaqc_upload:
         multiqc_json_dump = megaqc.multiqc_dump_json(report)
         if config.data_dump_file:
             util_functions.write_data_file(multiqc_json_dump, 'multiqc_data', False, 'json')


### PR DESCRIPTION
I added a progress bar with popovers for each section under the BamQC module to highlight outliers (any value which is more than 2 stdev away from the mean). Outliers are highlighted in red while passed values are in green. 

.travis.yml was changed so that it will check the version of python and exclude the BamQC module if the version is not 3 or beyond. (This is because BamQC imported `statistics` module to do calculations, but `statistics` module is not available in python 2.7.)

Also, some commits from the original repository since I forked were cherry-picked. 