### PR TITLE
Fastqc progress bars popovers and colours change

### DIFF
--- a/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
+++ b/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
@@ -82,6 +82,12 @@ $(function () {
         }).popover('show');
     });
 
+    $('html').on('click', function(e) {
+        if(!$(e.target).is('.progress-bar') && $(e.target).closest('.popover').length == 0) {
+            $('.mqc-section-bamqc .bamqc_passfail_progress .progress-bar').popover('hide');
+        }
+    });
+
     // Listener for Status higlight click
     $('.mqc-section-bamqc .bamqc_passfail_progress').on('click', '.bamqc-status-highlight', function(e){
         e.preventDefault();

--- a/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
+++ b/multiqc/modules/bamqc/assets/js/multiqc_bamqc.js
@@ -82,8 +82,9 @@ $(function () {
         }).popover('show');
     });
 
+    // dismiss a popover by clicking outside of it
     $('html').on('click', function(e) {
-        if(!$(e.target).is('.progress-bar') && $(e.target).closest('.popover').length == 0) {
+        if(!$(e.target).is('.progress-bar') && $('.popover').has(e.target).length == 0) {
             $('.mqc-section-bamqc .bamqc_passfail_progress .progress-bar').popover('hide');
         }
     });

--- a/multiqc/modules/fastqc/assets/css/multiqc_fastqc.css
+++ b/multiqc/modules/fastqc/assets/css/multiqc_fastqc.css
@@ -11,8 +11,8 @@
   overflow: auto;
 }
 .popover-success .popover-title {
-  background-color: #dff0d8;
-  color: #3c763d;
+  background-color: #c9eaf2;
+  color: #1d69ba;
 }
 .popover-warning .popover-title {
   background-color: #fcf8e3;
@@ -116,4 +116,4 @@
 #fastqc_seq_heatmap_key_t { border-bottom: 1px solid red; }
 #fastqc_seq_heatmap_key_c { border-bottom: 1px solid blue; }
 #fastqc_seq_heatmap_key_a { border-bottom: 1px solid green; }
-#fastqc_seq_heatmap_key_g { border-bottom: 1px solid black; }
+#fastqc_seq_heatmap_key_g { border-bottom: 1px solid pink; }

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -179,24 +179,26 @@ $(function () {
         var warn_number_of_digits = v['warn'].toString().length;
         var fail_number_of_digits = v['fail'].toString().length;
         var max_percent = Math.max(pass_percent, warn_percent, fail_percent);
+        var pass, warn, fail; // variable used to save the width in a progress-bar
         // Each digit needs around 8px of space
+        // The progress bar has a total width of 100px, so spaces allocated for pass, warn or fail will be calculated by their percentage * 100px
         if (max_percent == pass_percent) {
-            warn_percent = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
-            fail_percent = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
-            pass_percent = 100 - warn_percent - fail_percent;
+            warn = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
+            fail = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
+            pass = 100 - warn - fail;
         } else if (max_percent == warn_percent) {
-            pass_percent = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
-            fail_percent = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
-            warn_percent = 100 - pass_percent - fail_percent;
+            pass = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
+            fail = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
+            warn = 100 - pass - fail;
         } else {
-            pass_percent = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
-            warn_percent = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
-            fail_percent = 100 - pass_percent - warn_percent;
+            pass = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
+            warn = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
+            fail = 100 - pass - warn;
         }
         var p_bar = '<div class="progress fastqc_passfail_progress"> \
-            <div class="progress-bar progress-bar-success" style="width: '+pass_percent+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
-            <div class="progress-bar progress-bar-warning" style="width: '+warn_percent+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
-            <div class="progress-bar progress-bar-danger" style="width: '+fail_percent+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
+            <div class="progress-bar progress-bar-success" style="width: '+pass+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-warning" style="width: '+warn+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
+            <div class="progress-bar progress-bar-danger" style="width: '+fail+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
         </div>';
         $(pid).append(p_bar);
     });

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -179,26 +179,26 @@ $(function () {
         var warn_number_of_digits = v['warn'].toString().length;
         var fail_number_of_digits = v['fail'].toString().length;
         var max_percent = Math.max(pass_percent, warn_percent, fail_percent);
-        var pass, warn, fail; // variable used to save the width in a progress-bar
+        var pass_width, warn_width, fail_width; // variable used to save the width in a progress-bar
         // Each digit needs around 8px of space
         // The progress bar has a total width of 100px, so spaces allocated for pass, warn or fail will be calculated by their percentage * 100px
         if (max_percent == pass_percent) {
-            warn = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
-            fail = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
-            pass = 100 - warn - fail;
+            warn_width = calculateWidth(warn_percent, warn_number_of_digits, 100);
+            fail_width = calculateWidth(fail_percent, fail_number_of_digits, 100);
+            pass_width = 100 - warn_width - fail_width;
         } else if (max_percent == warn_percent) {
-            pass = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
-            fail = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
-            warn = 100 - pass - fail;
+            pass_width = calculateWidth(pass_percent, pass_number_of_digits, 100);
+            fail_width = calculateWidth(fail_percent, fail_number_of_digits, 100);
+            warn_width = 100 - pass_width - fail_width;
         } else {
-            pass = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
-            warn = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
-            fail = 100 - pass - warn;
+            pass_width = calculateWidth(pass_percent, pass_number_of_digits, 100);
+            warn_width = calculateWidth(warn_percent, warn_number_of_digits, 100);
+            fail_width = 100 - pass_width - warn_width;
         }
         var p_bar = '<div class="progress fastqc_passfail_progress"> \
-            <div class="progress-bar progress-bar-info" style="width: '+pass+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
-            <div class="progress-bar progress-bar-warning" style="width: '+warn+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
-            <div class="progress-bar progress-bar-danger" style="width: '+fail+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
+            <div class="progress-bar progress-bar-info" style="width: '+pass_width+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-warning" style="width: '+warn_width+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
+            <div class="progress-bar progress-bar-danger" style="width: '+fail_width+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
         </div>';
         $(pid).append(p_bar);
     });
@@ -474,7 +474,7 @@ function plot_single_seqcontent(s_name){
       type: 'line',
       zoomType: 'x'
     },
-    colors: ['#dc0000', '#0000dc', '#00dc00', '#404040'],
+    colors: ['#dc0000', '#0000dc', '#00dc00', '#ff96cd'],
     title: {
       text: s_name,
       x: 30 // fudge to center over plot area rather than whole plot
@@ -526,6 +526,24 @@ function plot_single_seqcontent(s_name){
   });
 }
 
+// Find the correct width for a progress bar to make all digits of a number visible
+function calculateWidth(percentage_result, number_of_digits, total_width) {
+  if (percentage_result == 0) {
+      // if the percentage being calculated is zero
+      // '0' does not need to be shown in a progress bar, so just return the original percentage
+      return percentage_result;
+  }
+  // each digit needs 8px, calculate the total space needed for a number
+  var space_expected = number_of_digits * 8;
+  // calculate the actual space for a number by multiplying the percentage by the total width of a progress bar
+  var space_actual = (percentage_result / 100) * total_width;
+  if (space_actual < space_expected) {
+      // the actual space is not large enough, return the amount of space we expected
+      return space_expected;
+  }
+  // the actual space is large enough, so do not need to expand it
+  return space_actual;
+}
 
 // Find the position of the mouse cursor over the canvas
 // http://stackoverflow.com/questions/6735470/get-pixel-color-from-canvas-on-mouseover

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -243,6 +243,13 @@ $(function () {
         }).popover('show');
     });
 
+    // dismiss a popover by clicking outside of it
+     $('html').on('click', function(e) {
+         if(!$(e.target).is('.progress-bar') && $('.popover').has(e.target).length == 0) {
+             $('.mqc-section-fastqc .fastqc_passfail_progress .progress-bar').popover('hide');
+         }
+     });
+
     // Listener for Status higlight click
     $('.mqc-section-fastqc .fastqc_passfail_progress').on('click', '.fastqc-status-highlight', function(e){
         e.preventDefault();

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -172,10 +172,31 @@ $(function () {
             total += 1;
             v[status] += 1;
         });
+        var pass_percent = (v['pass']/total)*100;
+        var warn_percent = (v['warn']/total)*100;
+        var fail_percent = (v['fail']/total)*100;
+        var pass_number_of_digits = v['pass'].toString().length;
+        var warn_number_of_digits = v['warn'].toString().length;
+        var fail_number_of_digits = v['fail'].toString().length;
+        var max_percent = Math.max(pass_percent, warn_percent, fail_percent);
+        // Each digit needs around 8px of space
+        if (max_percent == pass_percent) {
+            warn_percent = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
+            fail_percent = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
+            pass_percent = 100 - warn_percent - fail_percent;
+        } else if (max_percent == warn_percent) {
+            pass_percent = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
+            fail_percent = fail_percent != 0 && fail_percent < fail_number_of_digits * 8 ? fail_number_of_digits * 8 : fail_percent;
+            warn_percent = 100 - pass_percent - fail_percent;
+        } else {
+            pass_percent = pass_percent != 0 && pass_percent < pass_number_of_digits * 8 ? pass_number_of_digits * 8 : pass_percent;
+            warn_percent = warn_percent != 0 && warn_percent < warn_number_of_digits * 8 ? warn_number_of_digits * 8 : warn_percent;
+            fail_percent = 100 - pass_percent - warn_percent;
+        }
         var p_bar = '<div class="progress fastqc_passfail_progress"> \
-            <div class="progress-bar progress-bar-success" style="width: '+(v['pass']/total)*100+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
-            <div class="progress-bar progress-bar-warning" style="width: '+(v['warn']/total)*100+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
-            <div class="progress-bar progress-bar-danger" style="width: '+(v['fail']/total)*100+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
+            <div class="progress-bar progress-bar-success" style="width: '+pass_percent+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-warning" style="width: '+warn_percent+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
+            <div class="progress-bar progress-bar-danger" style="width: '+fail_percent+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
         </div>';
         $(pid).append(p_bar);
     });

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -196,7 +196,7 @@ $(function () {
             fail = 100 - pass - warn;
         }
         var p_bar = '<div class="progress fastqc_passfail_progress"> \
-            <div class="progress-bar progress-bar-success" style="width: '+pass+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
+            <div class="progress-bar progress-bar-info" style="width: '+pass+'%" title="'+v['pass']+'&nbsp;/&nbsp;'+total+' samples passed">'+v['pass']+'</div> \
             <div class="progress-bar progress-bar-warning" style="width: '+warn+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
             <div class="progress-bar progress-bar-danger" style="width: '+fail+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
         </div>';
@@ -211,7 +211,7 @@ $(function () {
         var pid = $(this).closest('h3').attr('id');
         var k = pid.substr(7);
         var vals = fastqc_passfails[k];
-        var passes = $(this).hasClass('progress-bar-success') ? true : false;
+        var passes = $(this).hasClass('progress-bar-info') ? true : false;
         var warns = $(this).hasClass('progress-bar-warning') ? true : false;
         var fails = $(this).hasClass('progress-bar-danger') ? true : false;
         var pclass = '';

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -87,7 +87,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.js = { 'assets/js/multiqc_fastqc.js' : os.path.join(os.path.dirname(__file__), 'assets', 'js', 'multiqc_fastqc.js') }
 
         # Colours to be used for plotting lines
-        self.status_colours = { 'pass': '#5cb85c', 'warn': '#f0ad4e', 'fail': '#d9534f', 'default': '#999' }
+        self.status_colours = { 'pass': '#64bdd6', 'warn': '#f0ad4e', 'fail': '#d9534f', 'default': '#999' }
 
         # Add to the general statistics table
         self.fastqc_general_stats()
@@ -318,7 +318,7 @@ class MultiqcModule(BaseMultiqcModule):
             'tt_label': '<b>Base {point.x}</b>: {point.y:.2f}',
             'colors': self.get_status_cols('per_base_sequence_quality'),
             'yPlotBands': [
-                {'from': 28, 'to': 100, 'color': '#c3e6c3'},
+                {'from': 28, 'to': 100, 'color': '#b7daff'},
                 {'from': 20, 'to': 28, 'color': '#e6dcc3'},
                 {'from': 0, 'to': 20, 'color': '#e6c3c3'},
             ]
@@ -367,7 +367,7 @@ class MultiqcModule(BaseMultiqcModule):
             'colors': self.get_status_cols('per_sequence_quality_scores'),
             'tt_label': '<b>Phred {point.x}</b>: {point.y} reads',
             'xPlotBands': [
-                {'from': 28, 'to': 100, 'color': '#c3e6c3'},
+                {'from': 28, 'to': 100, 'color': '#b7daff'},
                 {'from': 20, 'to': 28, 'color': '#e6dcc3'},
                 {'from': 0, 'to': 20, 'color': '#e6c3c3'},
             ]
@@ -617,7 +617,7 @@ class MultiqcModule(BaseMultiqcModule):
             'yPlotBands': [
                 {'from': 20, 'to': 100, 'color': '#e6c3c3'},
                 {'from': 5, 'to': 20, 'color': '#e6dcc3'},
-                {'from': 0, 'to': 5, 'color': '#c3e6c3'},
+                {'from': 0, 'to': 5, 'color': '#b7daff'},
             ]
         }
 
@@ -870,7 +870,7 @@ class MultiqcModule(BaseMultiqcModule):
             'yPlotBands': [
                 {'from': 20, 'to': 100, 'color': '#e6c3c3'},
                 {'from': 5, 'to': 20, 'color': '#e6dcc3'},
-                {'from': 0, 'to': 5, 'color': '#c3e6c3'},
+                {'from': 0, 'to': 5, 'color': '#b7daff'},
             ],
         }
 


### PR DESCRIPTION
* Changed progress bars to prevent digits from being cut off
* Changed popovers so they will be closed by clicking outside of them
* Made reports more friendly to users with colourblindness: removed the colour combination of red and green, changed green to blue